### PR TITLE
Override default notifyChanges behavior

### DIFF
--- a/generator/res/content_subclass.txt
+++ b/generator/res/content_subclass.txt
@@ -55,7 +55,7 @@
         // Version %15$d : Creation of the table
 %16$s        public static void upgradeTable(SQLiteDatabase db, int oldVersion, int newVersion) {
 
-            if (oldVersion < 1) {
+            if (oldVersion < %15$d) {
                 Log.i(LOG_TAG, "Upgrading from version " + oldVersion + " to " + newVersion
                         + ", data will be lost!");
 

--- a/generator/res/provider.txt
+++ b/generator/res/provider.txt
@@ -49,7 +49,7 @@ public class %3$sProvider extends ContentProvider {
 
     private static final UriMatcher sUriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
 
-	private enum UriType {
+    private enum UriType {
 %5$s
         private String mTableName;
         private String mType;
@@ -93,7 +93,7 @@ public class %3$sProvider extends ContentProvider {
             if (mDatabase != null) {
                 mDatabase.setLockingEnabled(true);
             }
-		}
+        }
 
         return mDatabase;
     }
@@ -147,8 +147,8 @@ public class %3$sProvider extends ContentProvider {
                 break;
         }
 
-		if (canNotify() == true)
-        	getContext().getContentResolver().notifyChange(uri, null);
+        if (canNotify() == true)
+            getContext().getContentResolver().notifyChange(uri, null);
         return result;
     }
 
@@ -184,7 +184,7 @@ public class %3$sProvider extends ContentProvider {
         // Notify with the base uri, not the new uri (nobody is watching a new
         // record)
         if (canNotify() == true)
-        	getContext().getContentResolver().notifyChange(uri, null);
+            getContext().getContentResolver().notifyChange(uri, null);
         return resultUri;
     }
 
@@ -236,7 +236,7 @@ public class %3$sProvider extends ContentProvider {
         // Notify with the base uri, not the new uri (nobody is watching a new
         // record)
         if (canNotify() == true)
-        	context.getContentResolver().notifyChange(uri, null);
+            context.getContentResolver().notifyChange(uri, null);
         return numberInserted;
     }
 
@@ -285,19 +285,16 @@ public class %3$sProvider extends ContentProvider {
     }
     
     private String[] addIdToSelectionArgs(String id, String[] selectionArgs) {
-    	int length = 0;
-    	if (selectionArgs != null)
-    		length = selectionArgs.length;
-    	String[] newSelectionArgs = new String[length + 1];
-    	// Add the ID
-    	newSelectionArgs[0] = id;
-    	// If there are more elements, add them in the right order
-    	if (length > 0) {
-    		for (int i = 1; i <= 1; i++) {
-    	    	newSelectionArgs[i] = selectionArgs[i-1];
-    		}
-    	}
-    	return newSelectionArgs;
+        
+        if (selectionArgs == null) {
+            return new String[] { id };
+        }
+
+        int length = selectionArgs.length;
+        String[] newSelectionArgs = new String[length + 1];
+        newSelectionArgs[0] = id;
+        System.arraycopy(selectionArgs, 0, newSelectionArgs, 1, length);
+        return newSelectionArgs;
     }
 
     @Override
@@ -318,14 +315,14 @@ public class %3$sProvider extends ContentProvider {
         switch (uriType) {
 %8$s                String id = uri.getPathSegments().get(1);
                 result = db.update(uriType.getTableName(), values, whereWithId(selection),
-                        addIdToSelectionArgs(id, selectionArgs));
+                    addIdToSelectionArgs(id, selectionArgs));
                 break;
 %9$s                result = db.update(uriType.getTableName(), values, selection, selectionArgs);
                 break;
         }
 
         if (canNotify() == true)
-        	getContext().getContentResolver().notifyChange(uri, null);
+            getContext().getContentResolver().notifyChange(uri, null);
         return result;
     }
 

--- a/generator/res/provider.txt
+++ b/generator/res/provider.txt
@@ -24,7 +24,7 @@ import java.util.ArrayList;
  * <p>
  * (More information available https://github.com/foxykeep/ContentProviderCodeGenerator)
  */
-public final class %3$sProvider extends ContentProvider {
+public class %3$sProvider extends ContentProvider {
 
     private static final String LOG_TAG = %3$sProvider.class.getSimpleName();
 
@@ -134,8 +134,8 @@ public final class %3$sProvider extends ContentProvider {
 
         switch (uriType) {
 %8$s                id = uri.getPathSegments().get(1);
-                result = db.delete(uriType.getTableName(), whereWithId(id, selection), 
-                        selectionArgs);
+                result = db.delete(uriType.getTableName(), whereWithId(selection),
+                        addIdToSelectionArgs(id, selectionArgs));
                 break;
 %9$s                result = db.delete(uriType.getTableName(), selection, selectionArgs);
                 break;
@@ -249,8 +249,8 @@ public final class %3$sProvider extends ContentProvider {
 
         switch (uriType) {
 %8$s                id = uri.getPathSegments().get(1);
-                c = db.query(uriType.getTableName(), projection, whereWithId(id, selection),
-                        selectionArgs, null, null, sortOrder);
+                c = db.query(uriType.getTableName(), projection, whereWithId(selection),
+                        addIdToSelectionArgs(id, selectionArgs), null, null, sortOrder);
                 break;
 %9$s                c = db.query(uriType.getTableName(), projection, selection, selectionArgs,
                         null, null, sortOrder);
@@ -263,17 +263,32 @@ public final class %3$sProvider extends ContentProvider {
         return c;
     }
 
-    private String whereWithId(String id, String selection) {
+    private String whereWithId(String selection) {
         StringBuilder sb = new StringBuilder(256);
         sb.append(BaseColumns._ID);
-        sb.append(" = ");
-        sb.append(id);
+        sb.append(" = ?");
         if (selection != null) {
             sb.append(" AND (");
             sb.append(selection);
             sb.append(')');
         }
         return sb.toString();
+    }
+    
+    private String[] addIdToSelectionArgs(String id, String[] selectionArgs) {
+    	int length = 0;
+    	if (selectionArgs != null)
+    		length = selectionArgs.length;
+    	String[] newSelectionArgs = new String[length + 1];
+    	// Add the ID
+    	newSelectionArgs[0] = id;
+    	// If there are more elements, add them in the right order
+    	if (length > 0) {
+    		for (int i = 1; i <= 1; i++) {
+    	    	newSelectionArgs[i] = selectionArgs[i-1];
+    		}
+    	}
+    	return newSelectionArgs;
     }
 
     @Override
@@ -293,8 +308,8 @@ public final class %3$sProvider extends ContentProvider {
 
         switch (uriType) {
 %8$s                String id = uri.getPathSegments().get(1);
-                result = db.update(uriType.getTableName(), values, whereWithId(id, selection),
-                        selectionArgs);
+                result = db.update(uriType.getTableName(), values, whereWithId(selection),
+                        addIdToSelectionArgs(id, selectionArgs));
                 break;
 %9$s                result = db.update(uriType.getTableName(), values, selection, selectionArgs);
                 break;

--- a/generator/res/provider.txt
+++ b/generator/res/provider.txt
@@ -33,9 +33,15 @@ public class %3$sProvider extends ContentProvider {
     protected static final String DATABASE_NAME = "%3$sProvider.db";
 
     public static final String AUTHORITY = "%4$s.provider.%3$sProvider";
+    
+    protected static boolean NOTIFY_DATASET_CHANGES = false;
 
     static {
         Uri.parse("content://" + AUTHORITY + "/integrityCheck");
+    }
+    
+    protected boolean canNotify() {
+    	return NOTIFY_DATASET_CHANGES;
     }
 
     // Version 1 : Creation of the database
@@ -141,7 +147,8 @@ public class %3$sProvider extends ContentProvider {
                 break;
         }
 
-        getContext().getContentResolver().notifyChange(uri, null);
+		if (canNotify() == true)
+        	getContext().getContentResolver().notifyChange(uri, null);
         return result;
     }
 
@@ -176,7 +183,8 @@ public class %3$sProvider extends ContentProvider {
 
         // Notify with the base uri, not the new uri (nobody is watching a new
         // record)
-        getContext().getContentResolver().notifyChange(uri, null);
+        if (canNotify() == true)
+        	getContext().getContentResolver().notifyChange(uri, null);
         return resultUri;
     }
 
@@ -227,7 +235,8 @@ public class %3$sProvider extends ContentProvider {
 
         // Notify with the base uri, not the new uri (nobody is watching a new
         // record)
-        context.getContentResolver().notifyChange(uri, null);
+        if (canNotify() == true)
+        	context.getContentResolver().notifyChange(uri, null);
         return numberInserted;
     }
 
@@ -315,7 +324,8 @@ public class %3$sProvider extends ContentProvider {
                 break;
         }
 
-        getContext().getContentResolver().notifyChange(uri, null);
+        if (canNotify() == true)
+        	getContext().getContentResolver().notifyChange(uri, null);
         return result;
     }
 

--- a/generator/res/provider.txt
+++ b/generator/res/provider.txt
@@ -283,9 +283,9 @@ public class %3$sProvider extends ContentProvider {
         }
         return sb.toString();
     }
-    
+
     private String[] addIdToSelectionArgs(String id, String[] selectionArgs) {
-        
+
         if (selectionArgs == null) {
             return new String[] { id };
         }

--- a/generator/res/provider.txt
+++ b/generator/res/provider.txt
@@ -134,8 +134,8 @@ public final class %3$sProvider extends ContentProvider {
 
         switch (uriType) {
 %8$s                id = uri.getPathSegments().get(1);
-                result = db.delete(uriType.getTableName(), whereWithId(id, selection), 
-                        selectionArgs);
+                result = db.delete(uriType.getTableName(), whereWithId(selection), 
+                        addIdToSelectionArgs(id, selectionArgs));
                 break;
 %9$s                result = db.delete(uriType.getTableName(), selection, selectionArgs);
                 break;
@@ -249,8 +249,8 @@ public final class %3$sProvider extends ContentProvider {
 
         switch (uriType) {
 %8$s                id = uri.getPathSegments().get(1);
-                c = db.query(uriType.getTableName(), projection, whereWithId(id, selection),
-                        selectionArgs, null, null, sortOrder);
+                c = db.query(uriType.getTableName(), projection, whereWithId(selection),
+                        addIdToSelectionArgs(id, selectionArgs), null, null, sortOrder);
                 break;
 %9$s                c = db.query(uriType.getTableName(), projection, selection, selectionArgs,
                         null, null, sortOrder);
@@ -262,18 +262,33 @@ public final class %3$sProvider extends ContentProvider {
         }
         return c;
     }
-
-    private String whereWithId(String id, String selection) {
+    
+    private String whereWithId(String selection) {
         StringBuilder sb = new StringBuilder(256);
         sb.append(BaseColumns._ID);
-        sb.append(" = ");
-        sb.append(id);
+        sb.append(" = ?");
         if (selection != null) {
             sb.append(" AND (");
             sb.append(selection);
             sb.append(')');
         }
         return sb.toString();
+    }
+    
+    private String[] addIdToSelectionArgs(String id, String[] selectionArgs) {
+    	int length = 0;
+    	if (selectionArgs != null)
+    		length = selectionArgs.length;
+    	String[] newSelectionArgs = new String[length + 1];
+    	// Add the ID
+    	newSelectionArgs[0] = id;
+    	// If there are more elements, add them in the right order
+    	if (length > 0) {
+    		for (int i = 1; i <= 1; i++) {
+    	    	newSelectionArgs[i] = selectionArgs[i-1];
+    		}
+    	}
+    	return newSelectionArgs;
     }
 
     @Override
@@ -293,8 +308,8 @@ public final class %3$sProvider extends ContentProvider {
 
         switch (uriType) {
 %8$s                String id = uri.getPathSegments().get(1);
-                result = db.update(uriType.getTableName(), values, whereWithId(id, selection),
-                        selectionArgs);
+                result = db.update(uriType.getTableName(), values, whereWithId(selection),
+                        addIdToSelectionArgs(id, selectionArgs));
                 break;
 %9$s                result = db.update(uriType.getTableName(), values, selection, selectionArgs);
                 break;


### PR DESCRIPTION
If there's the need to make different insert/update/replace queries, one would like to notify changes with `notifyChanges` only at the end of the whole process. As of now, changes are automatically notified at the end of each insert/update/delete.
By overriding the generated ContentProvider one could be able to override the default implementation.
Also, allowing the ContentProvider to be inherited from could let developers use some custom logic for join fake-Uris (which is something I'm doing) without having to manually edit the generated ContentProvider, by implementing that very logic in the inherited class.
