### PR TITLE
Incorrect instruction in the README about run using CLI

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,6 +33,7 @@ Building/Running from the CLI
     cd generator/bin
     ln -s ../res .
     javac $(find ../src -name *.java) -d .
+    mkdir input
     cp ../input/example/sample.json ./input
     java com/foxykeep/cpcodegenerator/Main
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ Building/Running from the CLI
     ln -s ../res .
     javac $(find ../src -name *.java) -d .
     mkdir input
-    cp ../input/example/sample.json ./input
+    cp ../example/sample.json ./input
     java com/foxykeep/cpcodegenerator/Main
 ```
 


### PR DESCRIPTION
When copy the sample.json to input using "cp ../input/example/sample.json ./input", it will copy the json as a file but not in input directory as there is no "input" folder. Fix it by create "input" directory explicitly before copying the json sample.
